### PR TITLE
faster divandmod

### DIFF
--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -209,6 +209,14 @@ class TestSymbolic(unittest.TestCase):
     with self.assertRaises(ZeroDivisionError):
       (Variable("a", 0, 7) % 0).simplify()
 
+  def test_zero_numerator(self):
+    a = Variable("a", 1, 10)
+    self.helper_test_variable(UOp.const_like(a, 0) // a, 0, 0, "0")
+    self.helper_test_variable(UOp.const_like(a, 0) % a, 0, 0, "0")
+    b = Variable("b", 0, 10)
+    self.assertEqual((UOp.const_like(b, 0) // b).simplify().render(), "(0//b)")
+    self.assertEqual((UOp.const_like(b, 0) % b).simplify().render(), "(0%b)")
+
   def test_sum_div_remove(self):
     self.helper_test_variable(usum([Variable("a", 0, 7), Variable("b", 0, 3)]) // 20, 0, 0, "0")
 

--- a/tinygrad/uop/divandmod.py
+++ b/tinygrad/uop/divandmod.py
@@ -1,4 +1,4 @@
-import functools
+import math, functools
 from tinygrad.uop.ops import PatternMatcher, UPat, Ops, UOp
 from tinygrad.dtype import dtypes
 from tinygrad.helpers import cdiv, cmod, CORRECT_DIVMOD_FOLDING, unwrap
@@ -12,12 +12,17 @@ def fold_divmod_general(d: UOp, correct_divmod_folding: bool) -> UOp|None:
   x_min, x_max, y_min, y_max = x.vmin, x.vmax, y.vmin, y.vmax
   assert isinstance(x_min, int) and isinstance(x_max, int) and isinstance(y_min, int) and isinstance(y_max, int)
   if y_min==y_max==0: raise ZeroDivisionError(f"{'Division' if d.op is Ops.IDIV else 'Mod'} by zero trying to rewrite {x.alu(d.op, y)}")
+  # 0//y = 0 and 0%y = 0 for any y != 0
+  if x_min==x_max==0: return d.const_like(0) if y_min > 0 else None
+  # normalize negative numerator/denominator to positive (need x_min<0 check to avoid -0=0 loop when x is exactly 0)
+  if y_max < 0: return (x%(-y)) if d.op is Ops.MOD else -(x//(-y))
+  if x_max <= 0 and x_min < 0: return -((-x)%y) if d.op is Ops.MOD else -((-x)//y)
   if y_min*y_max > 0 and (q:=cdiv(x_min,y_min)) == cdiv(x_min,y_max) == cdiv(x_max,y_min) == cdiv(x_max,y_max):
     return x - q*y if d.op is Ops.MOD else d.const_like(q)
 
   # split uops for the rest of the processing
   x_peeled, const = x.pop_const()
-  uops_no_const = list(x_peeled.split_uop(Ops.ADD))
+  uops_no_const = tuple(x_peeled.split_uop(Ops.ADD))
 
   # ** Constant Denominator Rules **
   # these rules strictly require y to be a scalar constant > 0
@@ -32,28 +37,42 @@ def fold_divmod_general(d: UOp, correct_divmod_folding: bool) -> UOp|None:
         new_xs.append(u)
       if changed and (new_x:=(UOp.sum(*new_xs) + const)).vmin >= 0: return new_x % y
 
-    # Shared decomposition for folding rules
-    decomp = [(u.divides(f:=u.const_factor()),f) for u in uops_no_const]
-    terms, factors = zip(*decomp)
-
     # fold_binary_numerator: fold if expression has one non-constant term that takes on two values
-    if len(terms)==1 and (v:=terms[0]).vmax-v.vmin == 1:
-      y1 = cmod(factors[0]*v.vmin+const, c) if d.op is Ops.MOD else cdiv(factors[0]*v.vmin+const, c)
-      y2 = cmod(factors[0]*v.vmax+const, c) if d.op is Ops.MOD else cdiv(factors[0]*v.vmax+const, c)
-      return (y2-y1)*(v-v.vmin) + y1
+    if len(uops_no_const)==1:
+      f = uops_no_const[0].const_factor()
+      if (v:=uops_no_const[0].divides(f)).vmax-v.vmin == 1:
+        y1 = cmod(f*v.vmin+const, c) if d.op is Ops.MOD else cdiv(f*v.vmin+const, c)
+        y2 = cmod(f*v.vmax+const, c) if d.op is Ops.MOD else cdiv(f*v.vmax+const, c)
+        return (y2-y1)*(v-v.vmin) + y1
+
+    # compute factors once for all remaining rules
+    factors = tuple(u.const_factor() for u in uops_no_const)
 
     # fold_divmod_congruence: fold if a is congruent to an expression whose range is between 0 and c
     if not (x.vmin<0 and correct_divmod_folding):
-      rems = [min((r:=f%c), r-c, key=abs) for f in factors]
-      if (rem:=sum(r*v for r,v in zip(rems,terms))+const%c).vmin//c==rem.vmax//c:
-        if d.op is Ops.MOD: return rem - rem.vmin//c*c
-        return sum((f-r)//c * v for f,r,v in zip(factors,rems,terms)) + (const-const%c+rem.vmin//c*c)//c
+      rems, var_min, var_max = [], 0, 0
+      for u, f in zip(uops_no_const, factors):
+        r = min((r0:=f%c), r0-c, key=abs)
+        rems.append(r)
+        if r == 0: continue
+        v_min, v_max = (u.vmin//f, u.vmax//f) if f > 0 else (u.vmax//f, u.vmin//f)
+        var_min, var_max = var_min + r*(v_min if r >= 0 else v_max), var_max + r*(v_max if r >= 0 else v_min)
+        if var_max - var_min >= c: break
+      const_rem = const % c
+      if (rem_min_floor := (var_min + const_rem)//c) == (var_max + const_rem)//c and var_max - var_min < c:
+        if d.op is Ops.MOD:
+          terms = [(u.divides(f)*r if r not in (0,1) else u.divides(f)) for u,f,r in zip(uops_no_const,factors,rems) if r != 0]
+          rem_expr = (UOp.sum(*terms) + const_rem) if (terms and const_rem) else (UOp.sum(*terms) if terms else x.const_like(const_rem))
+          return rem_expr - rem_min_floor*c if rem_min_floor else rem_expr
+        terms = [(u.divides(f)*q if q not in (0,1) else u.divides(f)) for u,f,r in zip(uops_no_const,factors,rems) if (q:=(f-r)//c) != 0]
+        quot_sum, const_quot = (UOp.sum(*terms) if terms else None), const//c + rem_min_floor
+        if quot_sum is None: return x.const_like(const_quot)
+        return (quot_sum + const_quot) if const_quot else quot_sum
 
     # gcd_with_remainder: factor out common gcd from numerator
-    # Note: this rule uses uops_no_const to exclude the additive constant from the GCD calculation
-    if x.vmin >= 0:
-      gcd = UOp.gcd(*uops_no_const, y).simplify()
-      if gcd.op is Ops.CONST and gcd.arg > 1:
+    if x.vmin >= 0 and factors:
+      if (gcd_val := functools.reduce(math.gcd, factors, c)) > 1:
+        gcd = x.const_like(gcd_val)
         new_x = unwrap(x_peeled.divide_exact(gcd)).simplify() + (const%c)//gcd.arg
         if new_x.vmin >= 0:
           ret = new_x.alu(d.op, x.ufix(c//gcd.arg))
@@ -68,17 +87,27 @@ def fold_divmod_general(d: UOp, correct_divmod_folding: bool) -> UOp|None:
 
   # ** Variable Denominator / Fallback Rules **
   # These rules apply to variables OR constants that failed the checks above.
-  # Reconstruct all uops including const for these checks.
-  all_uops = uops_no_const + ([x.const_like(const)] if const != 0 else [])
+
+  # compute factors if not already done
+  if y.op is not Ops.CONST or (c := y.arg) <= 0:
+    factors = tuple(u.const_factor() for u in uops_no_const)
 
   # divide_by_gcd: x//y -> (x//gcd)//(y//gcd)
-  gcd = UOp.gcd(*all_uops, y).simplify()
-  if not (gcd.op is Ops.CONST and gcd.arg==1):
+  if factors and y.op is Ops.CONST:
+    gcd_val = functools.reduce(math.gcd, (int(f) for f in factors), y.arg)
+    if const != 0: gcd_val = math.gcd(gcd_val, int(const))
+    gcd = None if gcd_val == 1 else x.const_like(gcd_val)
+  else:
+    # Reconstruct all uops including const for these checks.
+    all_uops = uops_no_const + ((x.const_like(const),) if const != 0 else ())
+    gcd = UOp.gcd(*all_uops, y).simplify()
+  if gcd is not None and not (gcd.op is Ops.CONST and gcd.arg==1):
     ret = unwrap(x.divide_exact(gcd)).alu(d.op, unwrap(y.divide_exact(gcd)))
     return ret*gcd if d.op is Ops.MOD else ret
 
   # factor_remainder: (d*x+y)//d -> x+y//d
-  if y.vmin<0 or x.vmin<0: return None
+  if y_min<0 or x_min<0: return None
+  all_uops = uops_no_const if const == 0 else (*uops_no_const, x.const_like(const))
   quo, rem = [], []
   for u in all_uops:
     if (q:=u.divide_exact(y)) is not None: quo.append(q)
@@ -88,25 +117,19 @@ def fold_divmod_general(d: UOp, correct_divmod_folding: bool) -> UOp|None:
     else: rem.append(u)
 
   if not quo: return None
-  new_x = sum(rem)+x.const_like(0)
+  new_x = UOp.sum(*rem) if rem else x.const_like(0)
   if new_x.vmin<0: return None
-  return new_x%y if d.op is Ops.MOD else new_x//y+sum(quo)
+  return new_x%y if d.op is Ops.MOD else new_x//y+UOp.sum(*quo)
 
 div_and_mod_symbolic = PatternMatcher([
-  # ** 1. Fast Inline Rules **
+  # (x//c+a)//d -> (x+a*c)//(c*d)
   ((UPat.var("x")//UPat.cvar("c") + UPat.cvar("a"))//UPat.cvar("d"), lambda x,c,a,d: (x+a*c)//(c*d)
-    if c.vmin>0 and d.vmin>0 and ((x.vmin>=0 and a.vmin>=0) or (x.vmax<=0 and a.vmax<=0)) else None),  # (x//c+a)//d -> (x+a*c)//(c*d)
-  (UPat.var("x", dtypes.index) // UPat.var("d"), lambda x,d: -(x//(-d)) if d.vmax < 0 else None),
-  (UPat.var("x", dtypes.index) // UPat.var("d"), lambda x,d: -((-x)//d) if x.vmax <= 0 else None),
+    if c.vmin>0 and d.vmin>0 and ((x.vmin>=0 and a.vmin>=0) or (x.vmax<=0 and a.vmax<=0)) else None),
+  # (x+c)//d -> (x+c%d)//d + c//d when c >= d (extract constant quotient)
   ((UPat.var("x", dtypes.index)+UPat.cvar("c", vec=False)).named("n")//UPat.cvar("d", vec=False),
     lambda x,c,n,d: ((x+c.arg%d.arg)//d + c.arg//d.arg) if c.arg%d.arg!=c.arg and x.vmin>=0 and n.vmin>=0 and d.arg>0 else None),
   ((UPat.var("x", dtypes.index)+UPat.cvar("c", vec=False)).named("n")//UPat.cvar("d", vec=False),
     lambda x,c,n,d: (-(-(c.arg%d.arg + x - (d.arg-1))//d) + c.arg//d.arg) if x.vmax<=0 and n.vmin>=0 and d.arg>0 else None),
-
-  # ** 2. Slow Rules **
+  # fold_divmod_general handles everything else
   (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),
-
-  # NOTE: these have to go at the bottom or TestSymbolicOps.test_var loops
-  (UPat.var("x", dtypes.index) % UPat.var("d"), lambda x,d: -((-x)%d) if x.vmax <= 0 else None),
-  (UPat.var("x", dtypes.index) % UPat.var("d"), lambda x,d: (x%(-d)) if d.vmax < 0 else None),
 ])


### PR DESCRIPTION
Faster logic. Early exits. Pull in cheap patters (this is ~50ms on benchmark, can revert).

No process replay changes



Master
```1547 /    7899 --     90.24 /    338.84 ms -- divandmod.py:107     (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),```
Branch
```1547 /    7899 --     27.38 /     47.42 ms -- divandmod.py:134     (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),```

Might be worth the extra lines.


Master
```
***** model tensor in     60.83 ms
***** model schedule in  414.92 ms
***** model rewrite in   1545.75 ms
***** model linearize in 133.85 ms
***** model verify in     40.30 ms
28381
all 2197.36 ms
```


Branch
```
***** model tensor in     61.61 ms
***** model schedule in  362.07 ms
***** model rewrite in   1305.29 ms
***** model linearize in 134.70 ms
***** model verify in     39.91 ms
28381
all 1905.23 ms
```