### PR TITLE
uop_given_valid

### DIFF
--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -310,7 +310,6 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
 
       for candidate in candidates:
         # if every branch in candidate gives the same simplified uop, we can rewrite the uop
-        if len(candidate) == 1 and len(candidates) == 1: continue
         if uop_topo is None: uop_topo = uop.toposort()
         if not any(X in uop_topo for X,_ in candidate): continue
         newuops = [substitute_simplify(uop, {X:newX}) for X,newX in candidate]

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -278,10 +278,7 @@ def substitute_simplify(uop:UOp, sub_dict:dict[UOp, UOp]) -> UOp:
   if not sub_dict: return uop
   new_uop = uop.substitute(sub_dict)
   if new_uop is uop: return uop
-  new_uop_simp = new_uop.simplify()
-  # skip reverse substitution if intermediate simplify did nothing - will just get back original uop
-  if new_uop_simp is new_uop: return uop
-  return new_uop_simp.substitute({v:k for k,v in sub_dict.items()}).simplify()
+  return new_uop.simplify().substitute({v:k for k,v in sub_dict.items()}).simplify()
 
 def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
   # return simplified uop (might be the same as input)

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -274,6 +274,15 @@ def parse_valid(v:UOp) -> tuple[UOp, bool, int]|None:
     # NOTE: v.src[1].op can be Ops.VCONST
   return None
 
+def substitute_simplify(uop:UOp, sub_dict:dict[UOp, UOp]) -> UOp:
+  if not sub_dict: return uop
+  new_uop = uop.substitute(sub_dict)
+  if new_uop is uop: return uop
+  new_uop_simp = new_uop.simplify()
+  # skip reverse substitution if intermediate simplify did nothing - will just get back original uop
+  if new_uop_simp is new_uop: return uop
+  return new_uop_simp.substitute({v:k for k,v in sub_dict.items()}).simplify()
+
 def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
   # return simplified uop (might be the same as input)
 
@@ -286,6 +295,7 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
 
   # simplify uop given that valid is True
   all_candidates = []
+  uop_topo = None
   for i,(expr,v) in enumerate(bounds.items()):
     v0, v1 = (expr.vmin if v[0] is None else v[0], expr.vmax if v[1] is None else v[1])
     # try checking the whole clause
@@ -300,18 +310,21 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
 
       for candidate in candidates:
         # if every branch in candidate gives the same simplified uop, we can rewrite the uop
-        newuops = [uop.substitute({X:newX}) for X,newX in candidate]
-        if any(u is uop for u in newuops): continue  # if any branch doesnt appear in uop, skip
-        newuops = [u.simplify().substitute({newX:X}).simplify() for (X,newX),u in zip(candidate,newuops)]
+        if len(candidate) == 1 and len(candidates) == 1: continue
+        if uop_topo is None: uop_topo = uop.toposort()
+        if not any(X in uop_topo for X,_ in candidate): continue
+        newuops = [substitute_simplify(uop, {X:newX}) for X,newX in candidate]
+        if any(u is uop for u in newuops): continue
         if all_same(newuops): uop = newuops[0]
         elif uop.op is Ops.VECTORIZE and len(uop.src) == 2:
           if all_same([uops.src[0] for uops in newuops]): uop = uop.replace(src=(newuops[0].src[0], uop.src[1]))
           if all_same([uops.src[1] for uops in newuops]): uop = uop.replace(src=(uop.src[0], newuops[0].src[1]))
 
   # try all the valids together (but only the whole expressions)
-  if (s_uop:=uop.substitute(sub_dict:=dict(all_candidates))) is not uop:
-    uop = s_uop.simplify().substitute({newX:X for X,newX in sub_dict.items()}).simplify()
-  return uop
+  if try_simplex and uop_topo is None: uop_topo = uop.toposort()
+  sub_dict = {expr: newX for expr,newX in all_candidates if not try_simplex or (uop_topo is not None and expr in uop_topo)}
+  if not sub_dict: return uop
+  return substitute_simplify(uop, sub_dict)
 
 def _valid_priority(v: UOp, valids:list[UOp]):
   # we want valid that's in other valids' parents to be first, so it's more likely the other valids get simplified

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -311,10 +311,10 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
         if not any(X in uop_topo for X,_ in candidate): continue
         newuops = [substitute_simplify(uop, {X:newX}) for X,newX in candidate]
         if any(u is uop for u in newuops): continue
-        if all_same(newuops): uop = newuops[0]
+        if all_same(newuops): uop, uop_topo = newuops[0], None
         elif uop.op is Ops.VECTORIZE and len(uop.src) == 2:
-          if all_same([uops.src[0] for uops in newuops]): uop = uop.replace(src=(newuops[0].src[0], uop.src[1]))
-          if all_same([uops.src[1] for uops in newuops]): uop = uop.replace(src=(uop.src[0], newuops[0].src[1]))
+          if all_same([uops.src[0] for uops in newuops]): uop, uop_topo = uop.replace(src=(newuops[0].src[0], uop.src[1])), None
+          if all_same([uops.src[1] for uops in newuops]): uop, uop_topo = uop.replace(src=(uop.src[0], newuops[0].src[1])), None
 
   # try all the valids together (but only the whole expressions)
   if try_simplex and uop_topo is None: uop_topo = uop.toposort()


### PR DESCRIPTION
early exits for `substitute(a).simplify().substitute(inv_a)`

main
```
***** model tensor in     61.69 ms
***** model schedule in  413.22 ms
***** model rewrite in   1519.84 ms
***** model linearize in 130.62 ms
***** model verify in     39.17 ms
28381
all 2166.22 ms
```


```
***** model tensor in     60.62 ms
***** model schedule in  383.93 ms
***** model rewrite in   1380.06 ms
***** model linearize in 135.63 ms
***** model verify in     39.22 ms
28381
all 2001.04 ms
```

main:

 ```
    15 /      90 --     22.57 /    152.69 ms -- simplify.py:40       (UPat((Ops.END, Ops.REDUCE), name="u"), simplify_merge_adjacent),
     7 /     333 --     96.55 /    208.97 ms -- symbolic.py:367      (UPat(Ops.AND, name="valid"), simplify_valid),
     6 /     139 --     51.13 /    225.74 ms -- devectorizer.py:50   (UPat(Ops.INDEX, src=(UPat.var("buf"), invalid_gate)), lambda buf,x,i,cond: simplify_valid_load(buf, x, cond)),
  1547 /    7899 --     87.59 /    334.13 ms -- divandmod.py:107     (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),
 99048 / 1259921 --    649.70 /   1956.52 ms -- TOTAL
 ```
 
 branch
```
   189 /   58676 --      2.04 /     63.01 ms -- symbolic.py:210      (UPat(GroupOp.ALU|{Ops.DEFINE_VAR, Ops.SPECIAL}, name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
     6 /     139 --     32.15 /     88.81 ms -- devectorizer.py:50   (UPat(Ops.INDEX, src=(UPat.var("buf"), invalid_gate)), lambda buf,x,i,cond: simplify_valid_load(buf, x, cond)),
     7 /     333 --     50.80 /    106.19 ms -- symbolic.py:380      (UPat(Ops.AND, name="valid"), simplify_valid),
    15 /      90 --     22.77 /    151.35 ms -- simplify.py:40       (UPat((Ops.END, Ops.REDUCE), name="u"), simplify_merge_adjacent),
  1647 /    5250 --     91.12 /    289.48 ms -- divandmod.py:107     (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),
 97298 / 1063428 --    587.69 /   1590.70 ms -- TOTAL
 ```
 


