### PR TITLE
1.3/1.08, clean split

### DIFF
--- a/test/external/external_test_onnx_ops.py
+++ b/test/external/external_test_onnx_ops.py
@@ -379,7 +379,7 @@ class TestContribOnnxOps(TestOnnxOps):
         inps = {**base_inps, **extra_inps}
         opts = {**base_opts, **extra_opts}
         outputs = ["output", "present"] if "past" in inps else ["output"]
-        self.helper_test_single_op("Attention", inps, opts, outputs, atol=1e-4)
+        self.helper_test_single_op("Attention", inps, opts, outputs, rtol=5e-3, atol=5e-3)
 
   def test_skip_layer_normalization(self):
     shape = (2, 8, 32)

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -540,5 +540,17 @@ def _helper_linearizer_opt_ast(realized_ast:UOp, real_bufs:list[Buffer], opts=[]
   for x in opts: # Check custom transformations if any.
     check_opt(([Opt(OptOps.TC, 0, (TC_SELECT.value, TC_OPT.value, 1))] if apply_tc else [])+x)
 
+class TestVectorAccumulator(unittest.TestCase):
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "test requires float4")
+  def test_reduce_vector_accumulator_no_dependency_chain(self):
+    x = Tensor.rand(256, 256).realize()
+    r = x.sum()
+    ast = r.schedule()[-1].ast
+    uops = get_program(ast, renderer=Device[Device.DEFAULT].renderer, opts=[Opt(OptOps.UNROLL, 0, 4)]).uops
+    accs = [u for u in uops if u.op is Ops.DEFINE_REG]
+    assert len(accs) == 1, f"expected 1 vector accumulator, got {len(accs)}"
+    acc_size = accs[0].dtype.size if hasattr(accs[0].dtype, 'size') else 1
+    assert acc_size == 4, f"accumulator should have size 4, got {acc_size}"
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -304,7 +304,7 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
     ended_ranges = flatten([x.ended_ranges for x in topo if x.op is Ops.END])
     input_ranges = tuple([x for x in topo if x.op is Ops.RANGE and x not in reduce_range and x not in ended_ranges])
     identity = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
-    # vector accumulator: no dependency chain between unrolled adds
+    # vector accumulator, no dependency chain between unrolled adds
     if (vec_count:=len(lst)) > 1 and red.dtype.count == 1:
       vec_dtype, idx0 = red.dtype.vec(vec_count), UOp.const(dtypes.int, 0)
       acc = UOp(Ops.DEFINE_REG, vec_dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -304,7 +304,7 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
     ended_ranges = flatten([x.ended_ranges for x in topo if x.op is Ops.END])
     input_ranges = tuple([x for x in topo if x.op is Ops.RANGE and x not in reduce_range and x not in ended_ranges])
     identity = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
-    # vector accumulator, no dependency chain between unrolled adds
+    # vector accumulator: no dependency chain between unrolled adds
     if (vec_count:=len(lst)) > 1 and red.dtype.count == 1:
       vec_dtype, idx0 = red.dtype.vec(vec_count), UOp.const(dtypes.int, 0)
       acc = UOp(Ops.DEFINE_REG, vec_dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -313,9 +313,8 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
       acc_out = acc.after(acc.index(idx0).store(new_val).end(*reduce_range)).index(idx0)
       ctx.acc_num += 1
       lanes = [acc_out.gep((i,)) for i in range(vec_count)]
-      while len(lanes) > 1:
-        lanes = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
-      return lanes[0]
+      pairs = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
+      return functools.reduce(lambda x,y: x.alu(red.arg, y), pairs) # pairwise sums then linear across: numerically closer ORT
     acc = UOp(Ops.DEFINE_REG, red.dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity) if len(input_ranges) else \
                acc.index(UOp.const(dtypes.int, 0)).store(identity)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -313,8 +313,9 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
       acc_out = acc.after(acc.index(idx0).store(new_val).end(*reduce_range)).index(idx0)
       ctx.acc_num += 1
       lanes = [acc_out.gep((i,)) for i in range(vec_count)]
-      pairs = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
-      return functools.reduce(lambda x,y: x.alu(red.arg, y), pairs) # pairwise sums then linear across: numerically closer ORT
+      while len(lanes) > 1:
+        lanes = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
+      return lanes[0]
     acc = UOp(Ops.DEFINE_REG, red.dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity) if len(input_ranges) else \
                acc.index(UOp.const(dtypes.int, 0)).store(identity)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -312,7 +312,9 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
       new_val = acc.after(acc_init, *reduce_range).index(idx0).alu(red.arg, UOp(Ops.VECTORIZE, vec_dtype, tuple(lst)))
       acc_out = acc.after(acc.index(idx0).store(new_val).end(*reduce_range)).index(idx0)
       ctx.acc_num += 1
-      return functools.reduce(lambda x,y: x.alu(red.arg, y), [acc_out.gep((i,)) for i in range(vec_count)])
+      lanes = [acc_out.gep((i,)) for i in range(vec_count)]
+      pairs = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
+      return functools.reduce(lambda x,y: x.alu(red.arg, y), pairs) # pairwise sums then linear across: numerically closer ORT
     acc = UOp(Ops.DEFINE_REG, red.dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity) if len(input_ranges) else \
                acc.index(UOp.const(dtypes.int, 0)).store(identity)


### PR DESCRIPTION
master
```
CPU=1 CPU_LLVM=1 BEAM=3 python3 test/speed/external_test_speed_v_torch.py TestSpeed.test_sum
sum                             2048x 2048    0.26 ms (    16.03 GFLOPS   64.13 GB/s) in torch,    2.88 ms (     1.46 GFLOPS    5.83 GB/s) in tinygrad,   11.01x slower       4.19 MOPS    16.78 MB
sum                             4096x 4096    1.02 ms (    16.43 GFLOPS   65.75 GB/s) in torch,   11.07 ms (     1.52 GFLOPS    6.07 GB/s) in tinygrad,   10.84x slower      16.78 MOPS    67.14 MB
```


branch
```
CPU=1 CPU_LLVM=1 BEAM=3 python3 test/speed/external_test_speed_v_torch.py TestSpeed.test_sum
sum                             2048x 2048    0.26 ms (    15.91 GFLOPS   63.59 GB/s) in torch,    0.36 ms (    11.66 GFLOPS   46.60 GB/s) in tinygrad,    1.36x slower       4.20 MOPS    16.78 MB
sum                             4096x 4096    1.04 ms (    16.35 GFLOPS   64.41 GB/s) in torch,    1.15 ms (    14.80 GFLOPS   58.31 GB/s) in tinygrad,    1.10x slower      17.04 MOPS    67.14 MB
```